### PR TITLE
FCBHDBP-362 etl-web frontend needs to pass contents of stocknumber.txt to Prevalidate lambda method and doesn't upload the stocknumber.txt file

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -35,6 +35,8 @@ import { debounce } from "debounce";
 import bibleBrain from "./BibleBrain.svg";
 import pLimit from 'p-limit';
 
+const STOCKNUMBER_FILE_NAME = 'stocknumber.txt';
+
 render(<App />, document.getElementById("app"));
 
 function App() {
@@ -422,7 +424,7 @@ function Upload() {
     let stocknumberFile: FileWithPath | null = null;
 
     acceptedFiles.forEach((file: FileWithPath) => {
-      if (file.name === 'stocknumber.txt') {
+      if (file.name === STOCKNUMBER_FILE_NAME) {
         stocknumberFile = file;
       }
     });
@@ -734,10 +736,23 @@ async function getArtifacts(uploadKey: string) {
   );
 }
 
+function getFilesWithoutStocknumberFile(files: FileWithPath[]): FileWithPath[] {
+  const filesFinal: FileWithPath[] = [];
+
+  files.forEach((file: FileWithPath) => {
+    if (file.name !== STOCKNUMBER_FILE_NAME) {
+      filesFinal.push(file);
+    }
+  });
+
+  return filesFinal;
+}
+
 async function uploadFiles(
-  files: FileWithPath[],
+  inputFiles: FileWithPath[],
   setUploadingMessage: (uploadingMessage: string) => void
 ): Promise<string> {
+  const files = getFilesWithoutStocknumberFile(inputFiles);
   // %Y-%m-%d-%H-%M-%S
   const uploadKey = new Date()
     .toISOString()


### PR DESCRIPTION
## Description
It has added a new feature to avoid to upload the stocknumber.txt file from UploadFiles method.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-362

## How Do I QA This

- Upload the files and you should see that the stocknumber.txt file should not be loaded.