### PR TITLE
FCBHDBP-362 etl-web frontend needs to pass contents of stocknumber.txt to Prevalidate lambda method and avoid to upload temp files.

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -736,11 +736,11 @@ async function getArtifacts(uploadKey: string) {
   );
 }
 
-function getFilesWithoutStocknumberFile(files: FileWithPath[]): FileWithPath[] {
+function getFilesWithoutTempStocknumberFile(files: FileWithPath[]): FileWithPath[] {
   const filesFinal: FileWithPath[] = [];
 
   files.forEach((file: FileWithPath) => {
-    if (file.name !== STOCKNUMBER_FILE_NAME) {
+    if (!file.name.startsWith(".")) {
       filesFinal.push(file);
     }
   });
@@ -752,7 +752,7 @@ async function uploadFiles(
   inputFiles: FileWithPath[],
   setUploadingMessage: (uploadingMessage: string) => void
 ): Promise<string> {
-  const files = getFilesWithoutStocknumberFile(inputFiles);
+  const files = getFilesWithoutTempStocknumberFile(inputFiles);
   // %Y-%m-%d-%H-%M-%S
   const uploadKey = new Date()
     .toISOString()


### PR DESCRIPTION
## Description
It has added a feature to avoid to upload temp files.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-362

## How Do I QA This

- Upload the files and you should see that the temp files (e.g. .`stocknumber.txt`) should not be loaded.