### PR TITLE
FCBHDBP-398  ETL Web: DatabaseCheck - debounce and give feedback 

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -111,12 +111,22 @@ function returnIframe(output: string) {
 
 function DatabaseCheck() {
   const [outputDatabaseCheck, setOutputDatabaseCheck] = useState("");
+  const [isLoadingDatabaseCheck, setIsLoadingDatabaseCheck] = useState(false);
+
+  const callDatabaseCheck = async () : Promise<void> => {
+    setIsLoadingDatabaseCheck(true);
+    setOutputDatabaseCheck(await runDatabaseCheckLambda());
+    setIsLoadingDatabaseCheck(false);
+  };
+
   return (
     <div>
       <h2>Database Check</h2>
-      <button onClick={callDatabaseCheck(setOutputDatabaseCheck)}>
+      <button onClick={callDatabaseCheck} disabled={isLoadingDatabaseCheck}>
         Run
       </button>
+      {isLoadingDatabaseCheck ? <p> Loading .... </p> : null}
+      <br />
       <br />
       {outputDatabaseCheck && returnIframe(outputDatabaseCheck)}
     </div>
@@ -940,9 +950,6 @@ const runDatabaseCheck = debounce(
   },
   1000,
 );
-
-const callDatabaseCheck = (setOutput: (output: string) => void) =>
-  () => runDatabaseCheck(setOutput);
 
 async function runPostvalidateLambda(filesetId: string): Promise<string> {
   try {


### PR DESCRIPTION
## Description

It has added the feature to disable the run button when the DatabaseCheck process is running and it will also display the message: 'loading'.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-371

## How Do I QA This
You should go to etldev website using the next URL: https://etldev.dev.dbt.io/ and you should click the new option `Database Check` and then click on `Run` button. After that, you should see that the button is disabled while the process is running.

## Screenshot
You can see the scre
![Peek 2022-07-08 16-02](https://user-images.githubusercontent.com/73488660/178069929-7dfe6680-d9fa-4b12-a7aa-bb9b2c5aa997.gif)
enshot about the UI 
